### PR TITLE
Do not crash if there is no debuginfo package

### DIFF
--- a/rebasehelper/checker.py
+++ b/rebasehelper/checker.py
@@ -350,14 +350,22 @@ class AbiCheckerTool(BaseChecker):
         """ Compares old and new RPMs using pkgdiff """
         cls.results_dir = results_dir
 
+        text = []
         debug_old, rest_pkgs_old = cls._get_packages_for_abipkgdiff(OutputLogger.get_build('old'))
         debug_new, rest_pkgs_new = cls._get_packages_for_abipkgdiff(OutputLogger.get_build('new'))
         cmd = [cls.CMD]
-        cmd.append('--d1')
-        cmd.append(debug_old[0])
-        cmd.append('--d2')
-        cmd.append(debug_new[0])
-        text = []
+        try:
+            cmd.append('--d1')
+            cmd.append(debug_old[0])
+        except IndexError:
+            text.append('Debuginfo package not found for old package.')
+            return text
+        try:
+            cmd.append('--d2')
+            cmd.append(debug_new[0])
+        except IndexError:
+            text.append('Debuginfo package not found for new package.')
+            return text
         for pkg in rest_pkgs_old:
             command = list(cmd)
             # Package can be <letters><numbers>-<letters>-<and_whatever>


### PR DESCRIPTION
In case we rebase some non-binary package, rebase helper failed with the following error:
```
Traceback (most recent call last):
  File "/home/hhorak/upstreams/github-hhorak/rebase-helper/rebase-helper.py", line 28, in <module>
    sys.exit(CliHelper.run())
  File "/home/hhorak/upstreams/github-hhorak/rebase-helper/rebasehelper/cli.py", line 138, in run
    app.run()
  File "/home/hhorak/upstreams/github-hhorak/rebase-helper/rebasehelper/application.py", line 481, in run
    self.pkgdiff_packages()
  File "/home/hhorak/upstreams/github-hhorak/rebase-helper/rebasehelper/application.py", line 447, in pkgdiff_packages
    text = self._execute_checkers(checker)
  File "/home/hhorak/upstreams/github-hhorak/rebase-helper/rebasehelper/application.py", line 436, in _execute_checkers
    text = pkgchecker.run_check(self.results_dir)
  File "/home/hhorak/upstreams/github-hhorak/rebase-helper/rebasehelper/checker.py", line 419, in run_check
    return self._tool.run_check(results_dir)
  File "/home/hhorak/upstreams/github-hhorak/rebase-helper/rebasehelper/checker.py", line 357, in run_check
    cmd.append(debug_old[0])
IndexError: list index out of range
```
The patch is just a quick fix.