### PR TITLE
Format error when raising already

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -167,7 +167,7 @@ class Application(object):
 
         # We want to inform user immediatelly if compare tool doesn't exists
         if self.conf.pkgcomparetool and self.conf.pkgcomparetool not in Checker.get_supported_tools():
-            raise RebaseHelperError('You have to specify one of these check tools %s', Checker.get_supported_tools())
+            raise RebaseHelperError('You have to specify one of these check tools %s' % Checker.get_supported_tools())
 
     def _get_rebase_helper_log(self):
         return os.path.join(self.results_dir, settings.REBASE_HELPER_RESULTS_LOG)
@@ -202,7 +202,7 @@ class Application(object):
         """
         self.spec_file_path = PathHelper.find_first_file(self.execution_dir, '*.spec', 0)
         if not self.spec_file_path:
-            raise RebaseHelperError("Could not find any SPEC file in the current directory '%s'", self.execution_dir)
+            raise RebaseHelperError("Could not find any SPEC file in the current directory '%s'" % self.execution_dir)
 
     def _delete_old_builds(self):
         """
@@ -269,14 +269,14 @@ class Application(object):
         try:
             archive = Archive(archive_path)
         except NotImplementedError as ni_e:
-            raise RebaseHelperError('%s. Supported archives are %s', ni_e.message, Archive.get_supported_archives())
+            raise RebaseHelperError('%s. Supported archives are %s' % (ni_e.message, Archive.get_supported_archives()))
 
         try:
             archive.extract_archive(destination)
         except IOError:
-            raise RebaseHelperError("Archive '%s' can not be extracted", archive_path)
+            raise RebaseHelperError("Archive '%s' can not be extracted" % archive_path)
         except (EOFError, SystemError):
-            raise RebaseHelperError("Archive '%s' is damaged", archive_path)
+            raise RebaseHelperError("Archive '%s' is damaged" % archive_path)
 
     @staticmethod
     def extract_sources(archive_path, destination):
@@ -354,7 +354,7 @@ class Application(object):
         try:
             builder = Builder(self.conf.buildtool)
         except NotImplementedError as ni_e:
-            raise RebaseHelperError('%s. Supported build tools are %s', ni_e.message, Builder.get_supported_tools())
+            raise RebaseHelperError('%s. Supported build tools are %s' % (ni_e.message, Builder.get_supported_tools()))
 
         for version in ['old', 'new']:
             spec_object = self.spec_file if version == 'old' else self.rebase_spec_file
@@ -388,14 +388,14 @@ class Application(object):
                     build_log = 'build.log'
                     build_log_path = os.path.join(rpm_dir, build_log)
                     if version == 'old':
-                        raise RebaseHelperError('Building old RPM package failed. Check log %s', build_log_path)
+                        raise RebaseHelperError('Building old RPM package failed. Check log %s' % build_log_path)
                     logger.error('Building binary packages failed.')
                     try:
                         files = BuildLogAnalyzer.parse_log(rpm_dir, build_log)
                     except BuildLogAnalyzerMissingError:
-                        raise RebaseHelperError('Build log %s does not exist', build_log_path)
+                        raise RebaseHelperError('Build log %s does not exist' % build_log_path)
                     except BuildLogAnalyzerMakeError:
-                        raise RebaseHelperError('Building package failed during build. Check log %s', build_log_path)
+                        raise RebaseHelperError('Building package failed during build. Check log %s' % build_log_path)
                     except BuildLogAnalyzerPatchError:
                         raise RebaseHelperError('Building package failed during patching. Check log %s' % build_log_path)
 
@@ -406,7 +406,7 @@ class Application(object):
                         deleted_files = '\n'.join(files['deleted'])
                         logger.warning('Removed files packaged in SPEC file:\n%s', deleted_files)
                     else:
-                        raise RebaseHelperError("Build failed, but no issues were found in the build log %s", build_log)
+                        raise RebaseHelperError("Build failed, but no issues were found in the build log %s" % build_log)
                     self.rebase_spec_file.modify_spec_files_section(files)
 
                 if not self.conf.non_interactive:

--- a/rebasehelper/checker.py
+++ b/rebasehelper/checker.py
@@ -185,7 +185,7 @@ class PkgDiffTool(BaseChecker):
             with open(file_name, 'w') as f:
                 f.writelines(lines)
         except IOError:
-            raise RebaseHelperError("Unable to create XML file for pkgdiff tool '%s'", file_name)
+            raise RebaseHelperError("Unable to create XML file for pkgdiff tool '%s'" % file_name)
 
         return file_name
 
@@ -305,7 +305,7 @@ class PkgDiffTool(BaseChecker):
          other return codes means error
         """
         if int(ret_code) != 0 and int(ret_code) != 1:
-            raise RebaseHelperError('Execution of %s failed.\nCommand line is: %s', cls.CMD, cmd)
+            raise RebaseHelperError('Execution of %s failed.\nCommand line is: %s' % (cls.CMD, cmd))
         OutputLogger.set_info_text('Result HTML page from pkgdiff is store in: ', cls.pkgdiff_results_full_path)
         results_dict = cls.process_xml_results(cls.results_dir)
         text = []
@@ -382,7 +382,7 @@ class AbiCheckerTool(BaseChecker):
                 output = os.path.join(results_dir, package_name)
                 ret_code = ProcessHelper.run_subprocess(command, output=output)
                 if int(ret_code) & settings.ABIDIFF_ERROR and int(ret_code) & settings.ABIDIFF_USAGE_ERROR:
-                    raise RebaseHelperError('Execution of %s failed.\nCommand line is: %s', cls.CMD, cmd)
+                    raise RebaseHelperError('Execution of %s failed.\nCommand line is: %s' % (cls.CMD, cmd))
                 if int(ret_code) == 0:
                     text.append('ABI of the compared binaries in package %s are equal.' % package_name)
                 else:

--- a/rebasehelper/output_tool.py
+++ b/rebasehelper/output_tool.py
@@ -155,7 +155,7 @@ class TextOutputTool(BaseOutputTool):
         try:
             LoggerHelper.add_file_handler(logger_output, path)
         except (OSError, IOError):
-            raise RebaseHelperError("Can not create results file '%s'", path)
+            raise RebaseHelperError("Can not create results file '%s'" % path)
 
         type_pkgs = ['old', 'new']
         cls.print_patches(OutputLogger.get_patches(), '\nSummary information about patches:')

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -150,7 +150,7 @@ class DownloadHelper(object):
                 curl.perform()
             except pycurl.error as error:
                 curl.close()
-                raise ReferenceError("Downloading '%s' failed with error '%s'.", url, error)
+                raise ReferenceError("Downloading '%s' failed with error '%s'." % (url, error))
 
             else:
                 curl.close()
@@ -536,7 +536,7 @@ One of the possible configuration can be:\n
 [merge]
     tool = mymeld
     conflictstyle = diff3"""
-            raise RebaseHelperError(message, git_config_name)
+            raise RebaseHelperError(message % git_config_name)
         return merge
 
     @staticmethod


### PR DESCRIPTION
I'm really not sure how the raising should work, but right now e.g. when merging is not defined in `~/.gitignore`, then we got error like this:
```
('[merge] section is not defined in %s.\n\nOne of the possible configuration can be:\n\n[mergetool 
"mymeld"]\n    cmd = meld --auto-merge --output $MERGED $LOCAL $BASE $REMOTE --diff $BASE
 $LOCAL --diff $BASE $REMOTE\n[merge]\n    tool = mymeld\n    conflictstyle = diff3', '/home/hhorak
/.gitconfig')
```
When using `%` instead of more arguments it works better, but maybe the more-arguments style should work as well... Only it doesn't :)