### PR TITLE
Amend commit message after applying patches with git am

### DIFF
--- a/rebasehelper/patch_helper.py
+++ b/rebasehelper/patch_helper.py
@@ -103,6 +103,9 @@ class GitPatchTool(PatchBase):
             if int(ret_code) != 0:
                 ret_code = git_helper.command_apply(input_file=patch_name, option=patch_option, ignore_space=True)
             ret_code = GitPatchTool.commit_patch(git_helper, patch_name)
+        else:
+            # replace last commit message with patch name to preserve mapping between commits and patches
+            ret_code = git_helper.command_commit(message='Patch: {0}'.format(os.path.basename(patch_name)), amend=True)
         return ret_code
 
     @classmethod

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -590,7 +590,7 @@ One of the possible configuration can be:\n
         cmd.append(directory)
         return self._call_git_command(cmd)
 
-    def command_commit(self, message=None):
+    def command_commit(self, message=None, amend=False):
 
         """
         Method commits message to Git
@@ -603,6 +603,9 @@ One of the possible configuration can be:\n
             cmd.extend(['-m', message])
         else:
             cmd.extend(['-m', 'Empty message'])
+
+        if amend:
+            cmd.append('--amend')
 
         return self._call_git_command(cmd)
 


### PR DESCRIPTION
Commit message needs to contain patch name (to be able to map
specific commit to specific patch later), but there is no control
over commit message when applying patches with git am.
This can be worked around by modifying commit message of the latest
commit using git commit --amend.

Closes #109