### PR TITLE
Copr support

### DIFF
--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -1,6 +1,8 @@
 # This can not be installed from pip, on Fedora you need to install rpm-python{,3}
 #rpm-python
 backports.lzma
+copr
 # This can not be installed in readthedocs.org
 #pycurl
+pyquery
 six

--- a/docs/upstreammonitoring.rst
+++ b/docs/upstreammonitoring.rst
@@ -18,7 +18,7 @@ But time changes and we are open to the another build systems.
 -- Python API usage::
 
    from rebasehelper.application import Application
-   cli = CLI([‘--non-interactive, ‘--builds-nowait’, ‘-buildtool’, ‘fedpkg’, upstream_version])
+   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', 'upstream_version'])
    rh = Application(cli)
    rh.set_upstream_monitoring() # Switch rebase-helper to upstream release monitoring mode.
    rh.run()
@@ -30,10 +30,10 @@ But time changes and we are open to the another build systems.
 - Download logs and RPMs for comparing with checkers
 -- Python API usage::
 
-   cli = CLI([‘--non-interactive, ‘--builds-nowait’, ‘--fedpkg-build-tasks old_id,new-id])
+   cli = CLI(['--non-interactive', '--builds-nowait', '--buildtool', 'fedpkg', '--build-tasks', 'old_id,new-id'])
    rh.run() # Downloads RPMs, logs and runs checkers and provides logs.
    rh.get_rebasehelper_data() # Get all information about the results
 -- Bash usage::
 
-   rebase-helper --non-interactive --builds-nowait --fedpkg-build-tasks old_id,new-id
+   rebase-helper --non-interactive --builds-nowait --buildtool fedpkg --build-tasks old_id,new-id
 

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -668,6 +668,11 @@ class Application(object):
         return rh_stuff
 
     def run(self):
+        if self.conf.fedpkg_build_tasks:
+            logger.warning("Option --fedpkg-build-tasks is deprecated, use --build-tasks instead.")
+            if not self.conf.build_tasks:
+                self.conf.build_tasks = self.conf.fedpkg_build_tasks
+
         if self.conf.build_tasks and not self.conf.builds_nowait:
             if self.conf.buildtool in ['fedpkg', 'copr']:
                 logger.error("--builds-nowait has to be specified with --build-tasks.")

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -646,7 +646,7 @@ class Application(object):
     def run(self):
         if self.conf.build_tasks and not self.conf.builds_nowait:
             if self.conf.buildtool == 'fedpkg':
-                logger.error("--builds-nowait has to be specified with --fedpkg-build-tasks.")
+                logger.error("--builds-nowait has to be specified with --build-tasks.")
                 return 1
             else:
                 logger.warning("Options are allowed only for fedpkg build tool. Suppress them.")

--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -31,7 +31,7 @@ from rebasehelper.specfile import SpecFile, get_rebase_name
 from rebasehelper.logger import logger, logger_report, LoggerHelper
 from rebasehelper import settings
 from rebasehelper import output_tool
-from rebasehelper.utils import PathHelper, RpmHelper, ConsoleHelper, GitHelper, KojiHelper, FileHelper
+from rebasehelper.utils import PathHelper, RpmHelper, ConsoleHelper, GitHelper, KojiHelper, FileHelper, CoprHelper
 from rebasehelper.checker import Checker
 from rebasehelper.build_helper import Builder, SourcePackageBuildError, BinaryPackageBuildError, koji_builder
 from rebasehelper.patch_helper import Patcher
@@ -449,15 +449,29 @@ class Application(object):
                                     break
                     else:
                         if self.conf.build_tasks:
-                            kh = KojiHelper()
-                            try:
-                                build_dict['rpm'], build_dict['logs'] = kh.get_koji_tasks(task_id, results_dir)
-                                OutputLogger.set_build_data(version, build_dict)
-                                if not build_dict['rpm']:
+                            if self.conf.buildtool == 'fedpkg':
+                                kh = KojiHelper()
+                                try:
+                                    build_dict['rpm'], build_dict['logs'] = kh.get_koji_tasks(task_id, results_dir)
+                                    OutputLogger.set_build_data(version, build_dict)
+                                    if not build_dict['rpm']:
+                                        return False
+                                except TypeError:
+                                    logger.info('Koji tasks are not finished yet. Try again later')
                                     return False
-                            except TypeError:
-                                logger.info('Koji tasks are not finished yet. Try again later')
-                                return False
+                            elif self.conf.buildtool == 'copr':
+                                copr_helper = CoprHelper()
+                                client = copr_helper.get_client()
+                                build_id = int(task_id)
+                                status = copr_helper.get_build_status(client, build_id)
+                                if status in ['importing', 'pending', 'starting', 'running']:
+                                    logger.info('Copr build is not finished yet. Try again later')
+                                    return False
+                                else:
+                                    build_dict['rpm'], build_dict['logs'] = copr_helper.download_build(client, build_id, results_dir)
+                                    if status not in ['succeeded', 'skipped']:
+                                        logger.info('Copr build {} did not complete successfully'.format(build_id))
+                                        return False
                     OutputLogger.set_build_data(version, build_dict)
                     break
 
@@ -612,6 +626,16 @@ class Application(object):
             data = logs[version]
             logger.info(message % (data['version'], data['koji_task_id']))
 
+    def print_copr_logs(self):
+        logs = self.get_new_build_logs()['build_ref']
+        copr_helper = CoprHelper()
+        client = copr_helper.get_client()
+        message = "Copr build for '%s' version is: %s"
+        for version in ['old', 'new']:
+            data = logs[version]
+            build_url = copr_helper.get_build_url(client, data['copr_build_id'])
+            logger.info(message % (data['version'], build_url))
+
     def set_upstream_monitoring(self):
         self.upstream_monitoring = True
 
@@ -645,11 +669,11 @@ class Application(object):
 
     def run(self):
         if self.conf.build_tasks and not self.conf.builds_nowait:
-            if self.conf.buildtool == 'fedpkg':
+            if self.conf.buildtool in ['fedpkg', 'copr']:
                 logger.error("--builds-nowait has to be specified with --build-tasks.")
                 return 1
             else:
-                logger.warning("Options are allowed only for fedpkg build tool. Suppress them.")
+                logger.warning("Options are allowed only for fedpkg or copr build tools. Suppress them.")
                 self.conf.build_tasks = self.conf.builds_nowait = False
 
         sources = None
@@ -668,7 +692,10 @@ class Application(object):
                 try:
                     build = self.build_packages()
                     if self.conf.builds_nowait and not self.conf.build_tasks:
-                        self.print_koji_logs()
+                        if self.conf.buildtool == 'fedpkg':
+                            self.print_koji_logs()
+                        elif self.conf.buildtool == 'copr':
+                            self.print_copr_logs()
                         return 0
                 except RuntimeError:
                     logger.error('Unknown error caused by build log analysis')

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -125,7 +125,7 @@ class CLI(object):
         # deprecated argument, kept for backward compatibility
         self.parser.add_argument(
             "--fedpkg-build-tasks",
-            dest="build_tasks",
+            dest="fedpkg_build_tasks",
             help=argparse.SUPPRESS
         )
         self.parser.add_argument(

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -65,7 +65,7 @@ class CLI(object):
         self.parser.add_argument(
             "--buildtool",
             default="mock",
-            help="Select the build tool [mock(default)|rpmbuild|fedpkg]"
+            help="Select the build tool [mock(default)|rpmbuild|fedpkg|copr]"
         )
         self.parser.add_argument(
             "--pkgcomparetool",
@@ -120,7 +120,7 @@ class CLI(object):
             "--builds-nowait",
             default=False,
             action="store_true",
-            help="It starts a koji builds and does not care how they finish. Useful for fedpkg build tool."
+            help="It starts koji or copr builds and does not care how they finish. Useful for fedpkg and copr build tools."
         )
         # deprecated argument, kept for backward compatibility
         self.parser.add_argument(

--- a/rebasehelper/cli.py
+++ b/rebasehelper/cli.py
@@ -122,8 +122,14 @@ class CLI(object):
             action="store_true",
             help="It starts a koji builds and does not care how they finish. Useful for fedpkg build tool."
         )
+        # deprecated argument, kept for backward compatibility
         self.parser.add_argument(
             "--fedpkg-build-tasks",
+            dest="build_tasks",
+            help=argparse.SUPPRESS
+        )
+        self.parser.add_argument(
+            "--build-tasks",
             dest="build_tasks",
             help="Specify comma-separated task ids, old task first."
         )

--- a/rebasehelper/tests/test_cli.py
+++ b/rebasehelper/tests/test_cli.py
@@ -42,6 +42,7 @@ class TestCLI(object):
                 'cont': True,
                 'non_interactive': True,
                 'comparepkgs': 'test_dir',
+                'fedpkg_build_tasks': None,
                 'build_tasks': '123456,654321',
                 'builds_nowait': True,
                 'results_dir': '/tmp/rebase-helper'}

--- a/rebasehelper/tests/test_cli.py
+++ b/rebasehelper/tests/test_cli.py
@@ -49,7 +49,7 @@ class TestCLI(object):
                      '--buildtool', 'rpmbuild', '--pkgcomparetool',
                      'rpmdiff', '--outputtool', 'xml', '--keep-workspace', '--not-download-sources', '--continue',
                      '--non-interactive', '--comparepkgs-only', 'test_dir',
-                     '--builds-nowait', '--fedpkg-build-tasks', '123456,654321',
+                     '--builds-nowait', '--build-tasks', '123456,654321',
                      '--results-dir', '/tmp/rebase-helper']
         cli = CLI(arguments)
         for key, value in cli.args.__dict__.items():

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -35,10 +35,13 @@ import locale
 import time
 import random
 import string
+import gzip
+import copr
+import pyquery
 
 import six
 from six import StringIO
-from six.moves import input
+from six.moves import input, urllib
 from distutils.util import strtobool
 from rebasehelper.exceptions import RebaseHelperError
 from rebasehelper.logger import logger
@@ -1069,6 +1072,113 @@ class KojiHelper(object):
                     DownloadHelper.download_file(cls.baseurl + base_path + '/' + filename,
                                                  full_path_name)
         return rpm_list, log_list
+
+
+class CoprHelper(object):
+
+    @classmethod
+    def get_client(cls):
+        try:
+            client = copr.CoprClient.create_from_file_config()
+        except (copr.client.exceptions.CoprNoConfException,
+                copr.client.exceptions.CoprConfigException):
+            raise RebaseHelperError(
+                'Missing or invalid copr configuration file')
+        else:
+            return client
+
+    @classmethod
+    def create_project(cls, client, project, chroot, description, instructions):
+        try:
+            client.create_project(projectname=project, chroots=[chroot],
+                                  description=description,
+                                  instructions=instructions)
+        except copr.client.exceptions.CoprRequestException:
+            # reuse existing project
+            pass
+
+    @classmethod
+    def build(cls, client, project, srpm):
+        try:
+            result = client.create_new_build(projectname=project, pkgs=[srpm])
+        except copr.client.exceptions.CoprRequestException:
+            raise RebaseHelperError('Failed to start copr build')
+        else:
+            return result.builds_list[0].build_id
+
+    @classmethod
+    def get_build_url(cls, client, build_id):
+        try:
+            result = client.get_build_details(build_id)
+        except copr.client.exceptions.CoprRequestException:
+            raise RebaseHelperError(
+                'Failed to get copr build details for id {}'.format(build_id))
+        else:
+            return '{}/coprs/{}/{}/build/{}/'.format(client.copr_url,
+                                                     client.username,
+                                                     result.project,
+                                                     build_id)
+
+    @classmethod
+    def get_build_status(cls, client, build_id):
+        try:
+            result = client.get_build_details(build_id)
+        except copr.client.exceptions.CoprRequestException:
+            raise RebaseHelperError(
+                'Failed to get copr build details for id {}'.format(build_id))
+        else:
+            return result.status
+
+    @classmethod
+    def watch_build(cls, client, build_id):
+        try:
+            while True:
+                status = cls.get_build_status(client, build_id)
+                if not status:
+                    return False
+                elif status in ['succeeded', 'skipped']:
+                    return True
+                elif status in ['failed', 'canceled', 'unknown']:
+                    return False
+                else:
+                    time.sleep(10)
+        except KeyboardInterrupt:
+            return False
+
+    @classmethod
+    def download_build(cls, client, build_id, destination):
+        logger.info('Downloading packages and logs for build %d', build_id)
+        try:
+            result = client.get_build_details(build_id)
+        except copr.client.exceptions.CoprRequestException:
+            raise RebaseHelperError(
+                'Failed to get copr build details for {}'.format(build_id))
+        rpms = []
+        logs = []
+        for _, url in six.iteritems(result.data['results_by_chroot']):
+            url = url if url.endswith('/') else url + '/'
+            d = pyquery.PyQuery(url, opener=lambda x: urllib.request.urlopen(x))
+            d.make_links_absolute()
+            for a in d('a[href$=\'.rpm\'], a[href$=\'.log.gz\']'):
+                fn = os.path.basename(urllib.parse.urlsplit(a.attrib['href']).path)
+                dest = os.path.join(destination, fn)
+                if fn.endswith('.src.rpm'):
+                    # skip source RPM
+                    continue
+                DownloadHelper.download_file(a.attrib['href'], dest)
+                if fn.endswith('.rpm'):
+                    rpms.append(dest)
+                elif fn.endswith('.log.gz'):
+                    extracted = dest.replace('.log.gz', '.log')
+                    try:
+                        with gzip.open(dest, 'rb') as archive:
+                            with open(extracted, 'wb') as f:
+                                f.write(archive.read())
+                    except (IOError, EOFError):
+                        raise RebaseHelperError(
+                            'Failed to extract {}'.format(dest))
+                    logs.append(extracted)
+        return rpms, logs
 
 
 class FileHelper(object):

--- a/rebasehelper/utils.py
+++ b/rebasehelper/utils.py
@@ -568,6 +568,8 @@ class RpmHelper(object):
         :return: 
         """
         ts = rpm.TransactionSet()
+        # disable signature checking
+        ts.setVSFlags(rpm._RPMVSF_NOSIGNATURES)
         h = None
         with open(rpm_name, "r") as f:
             h = ts.hdrFromFdno(f)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 # This can not be installed from pip, on Fedora you need to install rpm-python{,3}
 #rpm-python
 backports.lzma
+copr
 pycurl
+pyquery
 six


### PR DESCRIPTION
This is initial support for Copr as a build tool. It is based on fedpkg implementation, so the usage is similar. For example:
```
rebase-helper --buildtool copr \
              --builds-nowait \
              --copr-build-ids $OLD_BUILD_ID,$NEW_BUILD_ID \
              $NEW_VERSION
```

There are two new dependencies:
- copr (*python-copr* in Fedora)
- pyquery (*python-pyquery* in Fedora)

You will need to get your Copr API token: https://copr.fedorainfracloud.org/api/

Any comments are welcome.

@phracek: Could you test this, possibly with upstream monitoring?