### PR TITLE
Clear output data on Application initialization

### DIFF
--- a/rebasehelper/application.py
+++ b/rebasehelper/application.py
@@ -66,6 +66,8 @@ class Application(object):
         :param cli_conf: CLI object with configuration gathered from commandline
         :return: 
         """
+        OutputLogger.clear()
+
         self.conf = cli_conf
 
         if self.conf.verbose:

--- a/rebasehelper/base_output.py
+++ b/rebasehelper/base_output.py
@@ -31,6 +31,9 @@ class OutputData(object):
     def __init__(self):
         self.summary_information = {}
 
+    def clear(self):
+        self.summary_information.clear()
+
     def update_info(self, name,  data):
         """
         Function insert a new field into summary_information
@@ -75,6 +78,10 @@ class OutputLogger(object):
     patch class, check classes
     """
     out_logger = OutputData()
+
+    @classmethod
+    def clear(cls):
+        cls.out_logger.clear()
 
     @classmethod
     def set_info_text(cls, text, data):


### PR DESCRIPTION
When running multiple Application instances consecutively,
output data persist between runs and cause results to be incorrect.

Fix that by clearing output data just after Application instance
is created.

This resolves *the-new-hotness* related issue #174.